### PR TITLE
Add some user stories for variants PEP

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -12,6 +12,16 @@
 
 ## Rationale
 
+Variants user stories:
+
+- A user wants to install a version of numpy that is accelerated for my CPU architecture
+- A user wants to install a version of pytorch that is accelerated for my GPU architecture
+- A user wants to install a version of mpi4py that has certain features enabled (e.g. specific MPI implementations for my hardware)
+- A library maintainer wants to build their library for wasm32-wasi with and without pthreads support
+- A library maintainer wants to build their library for an Emscripten platform for pyodide with extensions for graphics compiled in
+- A library maintainer wants to provide packages of their game library using different graphics backends
+
+
 ## Specification
 
 ## Backward Compatibility

--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -14,11 +14,11 @@
 
 Variants user stories:
 
-- A user wants to install a version of numpy that is accelerated for my CPU architecture
-- A user wants to install a version of pytorch that is accelerated for my GPU architecture
-- A user wants to install a version of mpi4py that has certain features enabled (e.g. specific MPI implementations for my hardware)
+- A user wants to install a version of NumPy that is accelerated for their CPU architecture
+- A user wants to install a version of PyTorch that is accelerated for their GPU architecture
+- A user wants to install a version of mpi4py that has certain features enabled (e.g. specific MPI implementations for their hardware)
 - A library maintainer wants to build their library for wasm32-wasi with and without pthreads support
-- A library maintainer wants to build their library for an Emscripten platform for pyodide with extensions for graphics compiled in
+- A library maintainer wants to build their library for an Emscripten platform for Pyodide with extensions for graphics compiled in
 - A library maintainer wants to provide packages of their game library using different graphics backends
 
 


### PR DESCRIPTION
Add a few user stories across the Python ecosystem for variants that we may want to include in the PEP. These are rough ideas and some are stronger use cases compared to others. I wanted to note this down so they aren't forgotten.