### PR TITLE
Variant markers are evaluated from wheels

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -785,6 +785,10 @@ frobnicate; "foo :: bar :: baz" in variant_properties
 
 Implementations should support matching the values while ignoring whitespace.
 
+Variant marker expressions are evaluated against a wheel, not against the output of the provider plugins. An
+implementation selects the best variant for the current platform using the properties from the provider plugins, or it
+builds a wheel from a source distribution. It then evaluates the marker expression using the properties of that wheel.
+If a non-variant wheel was selected or built, all variant markers evaluate to `False`.
 
 ### Integration with installers
 


### PR DESCRIPTION
Clarify that variant markers are evaluated from wheels, not from the provider plugins directly.

Closes https://github.com/wheelnext/pep_xxx_wheel_variants/issues/65