### PR TITLE
Typo: `multi_values` instead of `multi_value`

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -1231,12 +1231,12 @@ class MyPlugin:
             VariantFeatureConfig(
                name="accelerated", 
                values=["yes"],
-               multi_values=False
+               multi_value=False
             ),
             VariantFeatureConfig(
                name="version", 
                values=["v1", "v2", "v3", "v4"],
-               multi_values=False
+               multi_value=False
             ),
         ]
 ```


### PR DESCRIPTION
I think the name of the attribute is `multi_value` as per https://wheelnext.dev/proposals/pepxxx_wheel_variant_support/#variant-feature-config