### PR TITLE
Move variantlib out of the normative part

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -1271,7 +1271,6 @@ evaluate to `False`.
 
 ## Reference implementation
 
-The [variantlib](https://github.com/wheelnext/variantlib) project contains a reference implementation of the protocol, querying plugins, variant filtering
-and ordering, validation, variant metadata reading and writing, and generating the `variants.json` index.
+The [variantlib](https://github.com/wheelnext/variantlib) project contains a reference implementation of all the protocols and algorithms introduced in this PEP, as well as a command-line tool to convert wheels, generate the `*-variants.json` index and query plugins.
 
 A client for installing variant wheels is implemented in [uv](https://github.com/astral-sh/uv).


### PR DESCRIPTION
I'm trying to remove non-normative content from the normative section. While variantlib is our reference implementation, it and its subcommands may change in the future, so it should be in the non-normative part.

I've also added a reference uv while at it, we can add some build backend references there too. I'm not entirely sure how to best phrase this, maybe we need to move transient examples such as (reference) implementations out of the PEP entirely.