### PR TITLE
Typos, nit and more concise normative variants sections

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -532,7 +532,7 @@ A variant lable must adhere to the following rules:
   - Between 1-16 characters
   - Using only `0-9`, `a-z`, `.` or `_` characters
 
-Equivalent regex: `[0-9a-z._]{1,16}`
+Equivalent regex: `^[0-9a-z._]{1,16}$`
 
 #### Build Tag and Variant Label
 


### PR DESCRIPTION
I've gone through the normative variants sections and fixed typos, some style issues and tried to make it more concise. Some are for internal consistency or consistency with the existing PEPs, others are for clarity or for reducing non-normative aspects.