### PR TITLE
Wheel Variants: update API endpoint

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -990,6 +990,7 @@ They are in the form of:
 An API endpoint specification is equivalent to the following Python pseudocode:
 
 ```python
+import inspect
 import {import path}
 
 if "{object path}":
@@ -997,7 +998,7 @@ if "{object path}":
 else:
     plugin = {import path}
 
-if callable(plugin):
+if inspect.isclass(plugin):
     plugin = plugin()
 ```
 

--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -1008,7 +1008,7 @@ a. in the `plugin-api` key of variant metadata, either explicitly or inferred fr
 
 b. as the value of an installed entry point in the `variant_plugins`. The name of said entry point is insignificant.
    This is optional but recommended, as it permits variant-related utilities to discover variant plugins installed
-   to the user's system.
+   to the user's environment.
 
 #### Behavior stability and versioning
 


### PR DESCRIPTION
Reintroduce an explicit "API endpoint" section, and update the specification to permit class-free usage.