### PR TITLE
Allow dependencies for provider plugins

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -477,8 +477,6 @@ while installing the wheel. Otherwise, their use can be limited to build time or
 list of supported variant properties is encoded into the variant metadata.
 
 Package managers must not install or run untrusted variant providers without the explicit user opt-in.
-Provider packages must not specify any dependencies, and the installer must ensure that no dependencies are installed if
-specified in the provider package metadata.
 
 It is recommended that the most commonly used plugins are either vendored, reimplemented, or locked to specific
 wheels after verifying their trustworthiness, to enable the ability to securely install variant wheels out-of-the-box.
@@ -1344,6 +1342,13 @@ PEP 517 and PEP 660 builds must be non-variant wheels by default as they can't d
 By using a separate `*-variants.json` file for shared metadata, it is possible to use variant wheels on an index that
 does not specifically support variant metadata. However, the index must permit distributing wheels that use the extended
 filename syntax and the JSON file.
+
+## Security Implications
+
+Externally installed provider plugins are at risk for supply-chain attacks. Provider plugins may choose to vendor their
+dependencies to avoid the risk of their dependencies being compromised in a new version, but should in any case aim to
+use the minimal number of dependencies. Other mitigations include locking provider plugins similar to runtime
+dependencies. These concerns do not apply to provider plugins that are vendored or reimplemented by the package manager.
 
 ## Reference implementation
 


### PR DESCRIPTION
Remove the constraint the provider plugins may not have dependencies.

# Rationale

* The ideal case is only using vendored or reimplemented provider plugins, where this concern does not apply. This will capture the vast majority of cases. We're already more secure than build backends, as build backends are executed by default and have no security recommendations (PEP 517 does not mention security).
* The design is inconsistent with all other places in Python packaging, which always allow dependencies and make this a user choice. This includes build backends, which have similar security considerations as providers. Many build backends depend on other packages, but those are core packages with low risk. Similarly, `twine` sits at the crucial place of publishing files and also has dependencies.
* The choice which parties are trusted is ultimately that of the user. It's not fundamentally more secure using a provider that vendors outdated version of core packages (say `packaging`, `cryptography` or `requests`) than to depend on those packages. As security-minded user, you need to vet your whole dependency tree and decide if all parties are trustworthy and have adequate security measures, rolling everything into one zip isn't an adequate mitigation.
* A much better solution is locking provider plugins. No dependencies is a sort of emulation of this, but it does not check hashes for the provider itself and makes auditing harder.
* Mandatory vendoring obscures the real dependency tree, making supply chain auditing harder.
* For packages with native modules, it's not possible vendor them without replicating their build system and tags in the provider too, which is not well-supported.