### PR TITLE
Wheel Variants: remove class instantiation support

### DIFF
--- a/docs/proposals/pepxxx_wheel_variant_support.md
+++ b/docs/proposals/pepxxx_wheel_variant_support.md
@@ -1024,8 +1024,7 @@ To make it easier to discover and install plugins, they should be published in t
 them. In particular, packages published to PyPI must not rely on plugins that need to be installed from other indexes
 
 Plugins are implemented as Python modules. The API specified in this PEP can either be implemented as top-level
-attributes and functions, or as members of a class. In the latter case, the class is instantiated prior to accessing
-them.
+attributes and functions, or as members of a class. In the latter case, they must be either static or class methods.
 
 #### API endpoint
 
@@ -1047,9 +1046,6 @@ if "{object path}":
     plugin = {import path}.{object path}
 else:
     plugin = {import path}
-
-if inspect.isclass(plugin):
-    plugin = plugin()
 ```
 
 API endpoints are used in two contexts:


### PR DESCRIPTION
Per https://github.com/wheelnext/pep_xxx_wheel_variants/issues/99

Not sure if we should also rewrite protocols to use `@classmethod` or not.